### PR TITLE
Adding configuration to enable or disable help text formatting

### DIFF
--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -174,6 +174,9 @@ class Help(BotPlugin):
             if len(cmd_doc) > 80:
                 cmd_doc = '{doc}...'.format(doc=cmd_doc[:77])
 
-        help_str = '- **{prefix}{name}** - {doc}\n'.format(prefix=prefix, name=name, doc=cmd_doc)
+        if not self.bot_config.DISABLE_HELP_FORMATTING:
+            help_str = '- **{prefix}{name}** - {doc}\n'.format(prefix=prefix, name=name, doc=cmd_doc)
+        else:
+            help_str = '- {prefix}{name} - {doc}\n'.format(prefix=prefix, name=name, doc=cmd_doc)
 
         return help_str


### PR DESCRIPTION
Adding configuration DISABLE_HELP_FORMATTING to enable or disable help text formatting. This way users can simply copy and paste the commands from the help text in Slack. 